### PR TITLE
Typo in header

### DIFF
--- a/buzzer-music.X/buzzer-music.h
+++ b/buzzer-music.X/buzzer-music.h
@@ -86,6 +86,6 @@ bit buzzerMusicIsPlaying();
 
 // You should call this regularly while playing music (and it is OK to call it
 // at other times too).
-void buzzerMusicSerivce();
+void buzzerMusicService();
 
 #endif


### PR DESCRIPTION
Causes `buzzerMusicService` to lack the prototype before being used in `main.c` thus declared as returning `int` and thus getting a compile error.